### PR TITLE
Reg 60

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-bootstrap": "^0.30.8",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.3",
+    "react-router-bootstrap": "^0.24.2",
     "react-router-dom": "^4.0.0",
     "redux": "^3.5.2",
     "redux-persist": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-redux": "^5.0.3",
     "react-router-dom": "^4.0.0",
     "redux": "^3.5.2",
+    "redux-persist": "^4.6.0",
     "sass-loader": "^6.0.3",
     "serve": "^5.1.1",
     "underscore": "^1.8.3"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Navbar, Nav, NavItem, Glyphicon } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import styles from '../../public/stylesheets/header.css';
 
 const Header = () => (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -14,8 +14,12 @@ const Header = () => (
       </Navbar.Header>
       <Navbar.Collapse>
         <Nav pullRight>
-          <NavItem eventKey={1} href="/settings"><Glyphicon glyph="cog" /></NavItem>
-          <NavItem eventKey={2} href="#"><Glyphicon glyph="log-out" /></NavItem>
+          <LinkContainer to="/settings">
+            <NavItem eventKey={1}><Glyphicon glyph="cog" /></NavItem>
+          </LinkContainer>
+          <LinkContainer to="#">
+            <NavItem eventKey={2}><Glyphicon glyph="log-out" /></NavItem>
+          </LinkContainer>
         </Nav>
       </Navbar.Collapse>
     </Navbar>

--- a/src/components/NavPanel.jsx
+++ b/src/components/NavPanel.jsx
@@ -1,14 +1,21 @@
 import React, { PropTypes } from 'react';
 import { Nav, NavItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import styles from './../../public/stylesheets/navpanel.css';
 
 
 const NavPanel = ({ active }) => (
   <div className={styles.navpanel}>
     <Nav className={styles.pills} stacked activeKey={active} >
-      <NavItem eventKey={1} className={styles.item} href="/">Home</NavItem>
-      <NavItem eventKey={2} className={styles.item} href="#">Create/Edit Plan of Study</NavItem>
-      <NavItem eventKey={3} className={styles.item} disabled>Other Stuff</NavItem>
+      <LinkContainer to="/">
+        <NavItem eventKey={1} className={styles.item}>Home</NavItem>
+      </LinkContainer>
+      <LinkContainer to="#">
+        <NavItem eventKey={2} className={styles.item}>Create/Edit Plan of Study</NavItem>
+      </LinkContainer>
+      <LinkContainer to="#">
+        <NavItem eventKey={3} className={styles.item} disabled>Other Stuff</NavItem>
+      </LinkContainer>
     </Nav>
   </div>
 );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,17 +1,24 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { createStore } from 'redux';
+import { compose, createStore } from 'redux';
 import { Provider } from 'react-redux';
-
+import { autoRehydrate, persistStore } from 'redux-persist';
 import App from './components/App';
 import reducer from './reducers/AccountPageReducer';
+
+const devTools = window.devToolsExtension ? window.devToolsExtension() : f => f;
 
 /* eslint-disable no-underscore-dangle */
 const store = createStore(
   reducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+  compose(
+    devTools(),
+    autoRehydrate(),
+  ),
 );
 /* eslint-enable */
+
+persistStore(store);
 
 render(
   <Provider store={store}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from 'react-dom';
 import { compose, createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { autoRehydrate, persistStore } from 'redux-persist';
 import App from './components/App';
 import reducer from './reducers/AccountPageReducer';
 
@@ -13,12 +12,9 @@ const store = createStore(
   reducer,
   compose(
     devTools(),
-    autoRehydrate(),
   ),
 );
 /* eslint-enable */
-
-persistStore(store);
 
 render(
   <Provider store={store}>

--- a/src/reducers/PersistReducer.jsx
+++ b/src/reducers/PersistReducer.jsx
@@ -1,0 +1,14 @@
+const initialState = {};
+
+const PersistReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'persist/REHYDRATE':
+      return Object.assign({}, state, {
+        persistedState: action.payload,
+      });
+    default:
+      return state;
+  }
+};
+
+export default PersistReducer;

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import LoginReducer from './LoginReducer';
 import RegisterReducer from './RegisterReducer';
 import AccountPageReducer from './AccountPageReducer';
+import PersistReducer from './PersistReducer';
 
 const registerApp = combineReducers({
   AccountPageReducer,
   LoginReducer,
   RegisterReducer,
+  PersistReducer,
 });
 
 export default registerApp;


### PR DESCRIPTION
https://olinjs.atlassian.net/browse/REG-60

This branch makes Redux state persist using redux-persist and wraps all NavItems in a  LinkComponent tag to make them into react-router links. The state is stored so that when the page is refreshed, the state mirrors what it was prior to the refresh. Converting all navigation links to react-router links allows the page to be redirected on the client side, without reloading the state.